### PR TITLE
Enable basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 To run:
 
+```sh
 1. npm install
-2. node ./bin/www 
-
+2. npm start    // runs the app with Basic Auth enabled (user:pass as credentials)
+```
 
 ## Endpoints
+
+**GET** /health Returns "UP" with status code 200 when service is running. Useful to test authentication and service status.
 
 **GET** /market/rate/<token_in>/<token_out>
 

--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const basicAuth = require('express-basic-auth')
 const wallet_router = require('./routes/wallet')
 const anchor_router = require('./routes/anchor')
 const server_router = require('./routes/server')
@@ -7,6 +8,33 @@ const market_router = require('./routes/market')
 const app = express()
 
 app.use(express.json());
+app.use(
+    basicAuth({
+        authorizer: (username, password) => {
+            const httpUser = app.get("httpUser");
+            const httpPassword = app.get("httpPassword");
+
+            if (httpUser == undefined || httpPassword == undefined) {
+                return true;
+            }
+
+            if (httpUser.length == 0 || httpPassword.length == 0) {
+                return true;
+            }
+
+            const userMatches = basicAuth.safeCompare(username, httpUser);
+            const passwordMatches = basicAuth.safeCompare(password, httpPassword);
+
+            return userMatches & passwordMatches
+        },
+        challenge: true,
+        realm: "app"
+    })
+);
+
+app.get('/health', (req, res) => {
+    res.send('UP');
+});
 
 app.use('/wallet', wallet_router);
 app.use('/anchor', anchor_router);

--- a/bin/www
+++ b/bin/www
@@ -10,9 +10,18 @@ var http = require('http');
 /**
  * Get port from environment and store in Express.
  */
+const port = normalizePort(process.env.PORT || '4938'); // Changed default port to '4938'
 
-var port = normalizePort(process.env.PORT || '4938'); // Changed default port to '4938'
+/**
+ * Get process arguments
+ */
+const appArgs = process.argv.slice(2);
+const httpUser = appArgs[0] || "";
+const httpPassword = appArgs[1] || "";
+
 app.set('port', port);
+app.set('httpUser', httpUser);
+app.set('httpPassword', httpPassword);
 
 /**
  * Create HTTP server.
@@ -85,5 +94,5 @@ function onListening() {
   var bind = typeof addr === 'string'
     ? 'pipe ' + addr
     : 'port ' + addr.port;
-  //debug('Listening on ' + bind);
+  //console.log('Listening on ' + bind);
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "picopay-api",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "bin/wwww",
   "scripts": {
+    "start": "node ./bin/www user pass",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Hugo Urquiza",
@@ -13,6 +14,7 @@
     "@terra-money/terra.js": "^3.0.8",
     "bip39": "^3.0.4",
     "express": "^4.17.3",
+    "express-basic-auth": "^1.2.1",
     "isomorphic-fetch": "^3.0.0"
   }
 }


### PR DESCRIPTION
* Enables Basic Auth for all endpoints
* Defaults credentials are user:pass when running with "npm start". The following commands are the same:
```sh
npm start
```
```sh
node ./bin/www user pass
```

* Basic Auth can be disabled with calling the process without extra arguments
```sh
node ./bin/www
```
